### PR TITLE
✨ Feature/#39 공통 필드용 매핑 슈퍼클래스 도입 

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/configuration/jpa/JpaConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/configuration/jpa/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.likelion.backendplus4.talkpick.backend.common.configuration.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/entity/BaseAuditableEntity.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/entity/BaseAuditableEntity.java
@@ -1,0 +1,27 @@
+package com.likelion.backendplus4.talkpick.backend.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseAuditableEntity {
+
+	@CreatedDate
+	@Column(name = "created_time")
+	private LocalDateTime createdTime;
+
+	@LastModifiedDate
+	@Column(name = "updated_time")
+	private LocalDateTime updatedTime;
+
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/entity/BaseSoftDeleteEntity.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/entity/BaseSoftDeleteEntity.java
@@ -1,0 +1,19 @@
+package com.likelion.backendplus4.talkpick.backend.common.entity;
+
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@MappedSuperclass
+public abstract class BaseSoftDeleteEntity extends BaseAuditableEntity{
+
+	private boolean isDelete;
+
+	public void markAsDeleted() {
+		this.isDelete = true;
+	}
+
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/sample/entity/SampleEntity.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/sample/entity/SampleEntity.java
@@ -1,0 +1,23 @@
+package com.likelion.backendplus4.talkpick.backend.common.sample.entity;
+
+import com.likelion.backendplus4.talkpick.backend.common.entity.BaseSoftDeleteEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SampleEntity extends BaseSoftDeleteEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+}


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)

- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결

## ✨ 변경 사항
생성일자(`createdTime`), 수정일자(`updatedTime`), 삭제여부(`isDelete`) 같은 공통 필드를  
`@MappedSuperclass` 기반의 추상 클래스에서 관리하도록 개선했습니다.

- **BaseAuditableEntity** (`@MappedSuperclass`)  
  - `createdTime` (`@CreatedDate`): 엔티티 최초 저장 시 자동 채워짐  
  - `updatedTime` (`@LastModifiedDate`): 엔티티 수정 시 자동 갱신  
- **BaseSoftDeleteEntity** (extends `BaseAuditableEntity`)  
  - `isDelete`: 논리 삭제 플래그  
  - `markAsDeleted()`: 호출 시 `isDelete = true`로 변경  

### 예시: SampleEntity
```java
@Entity
public class SampleEntity extends BaseSoftDeleteEntity {
    @Id @GeneratedValue
    private Long id;
    // createdTime, updatedTime, isDelete는 상속으로 자동 관리
}
```
## 🔍 리뷰어에게
이번 PR에서 도입된 두 개의 추상 매핑 슈퍼클래스의 역할과 기능을 처음 접하는 분들을 위해 상세히 설명드립니다.
- BaseAuditableEntity
  - `@MappedSuperclass`와 `@EntityListeners(AuditingEntityListener.class)`를 사용해 엔티티의 생성·수정 시각을 자동으로 관리합니다.
  - `@CreatedDate`가 붙은 `createdTime`은 최초 저장 시점에, `@LastModifiedDate`가 붙은 `updatedTime`은 엔티티가 변경될 때마다 자동으로 기록됩니다.
- BaseSoftDeleteEntity
  - BaseAuditableEntity를 상속하며, 여기에 소프트 삭제 기능을 추가했습니다.
    - `isDelete` 플래그를 통해 “삭제” 대신 “비활성화” 상태를 표시하고, `markAsDeleted()` 호출로 해당 플래그를 true로 변경할 수 있습니다. 
    - 이 방식을 사용하면 실제 데이터를 물리 삭제하지 않고도, 조회 시 `isDelete = false` 조건만 추가하여 삭제된 레코드를 제외할 수 있습니다.

> **Tip:** 모든 엔티티가 반드시 두 클래스를 상속해야 하는 것은 아니며,  
> 생성·수정 시간 관리만 필요한 경우 `BaseAuditableEntity`만,  
> 소프트 삭제 기능이 필요 없는 경우 둘 다 생략하고 직접 필드 선언도 가능합니다.

## ✅ PR 체크리스트

- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.

## 🔗 관련 이슈
- closed #39 