### PR TITLE
✨  Feature/#7-Elasticsearch-검색-기능

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/configuration/elasticsearch/ElasticsearchConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/configuration/elasticsearch/ElasticsearchConfig.java
@@ -1,0 +1,7 @@
+package com.likelion.backendplus4.talkpick.backend.common.configuration.elasticsearch;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchConfig {
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/port/in/NewsSearchUseCase.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/port/in/NewsSearchUseCase.java
@@ -1,0 +1,24 @@
+package com.likelion.backendplus4.talkpick.backend.search.application.port.in;
+
+import java.util.List;
+
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearch;
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearchResult;
+
+/**
+ * 뉴스 검색 유스케이스 포트 인터페이스
+ *
+ * @author 정안식
+ * @since 2025-05-15
+ */
+public interface NewsSearchUseCase {
+	/**
+	 * 도메인 모델을 기반으로 검색 결과를 조회한다.
+	 *
+	 * @param newsSearch 검색어 및 페이징 정보 도메인 모델
+	 * @return 뉴스 검색 도메인 결과 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	List<NewsSearchResult> searchByMatch(NewsSearch newsSearch);
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/port/in/mapper/NewsSearchRequestMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/port/in/mapper/NewsSearchRequestMapper.java
@@ -1,0 +1,26 @@
+package com.likelion.backendplus4.talkpick.backend.search.application.port.in.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearch;
+import com.likelion.backendplus4.talkpick.backend.search.presentation.controller.dto.request.NewsSearchRequest;
+
+/**
+ * 요청 DTO를 도메인 모델로 변환하는 매퍼 클래스
+ *
+ * @since 2025-05-15
+ */
+@Component
+public class NewsSearchRequestMapper {
+	/**
+	 * 요청 DTO를 NewsSearch 도메인 모델로 변환한다.
+	 *
+	 * @param req 변환할 요청 DTO
+	 * @return 생성된 도메인 모델 객체
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	public static NewsSearch toDomain(NewsSearchRequest req) {
+		return new NewsSearch(req.getQ(), req.getPage(), req.getSize());
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/port/in/mapper/NewsSearchResponseMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/port/in/mapper/NewsSearchResponseMapper.java
@@ -1,0 +1,55 @@
+package com.likelion.backendplus4.talkpick.backend.search.application.port.in.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearchResult;
+import com.likelion.backendplus4.talkpick.backend.search.presentation.controller.dto.response.NewsSearchResponse;
+import com.likelion.backendplus4.talkpick.backend.search.presentation.controller.dto.response.NewsSearchResponseList;
+
+/**
+ * 도메인 모델을 응답 DTO로 변환하는 매퍼 클래스
+ *
+ * @author 정안식
+ * @since 2025-05-15
+ */
+public class NewsSearchResponseMapper {
+
+	/**
+	 * 단일 도메인 모델을 응답 DTO로 변환한다.
+	 *
+	 * @param d 변환할 도메인 모델
+	 * @return 변환된 응답 DTO
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	public static NewsSearchResponse toResponse(NewsSearchResult d) {
+		return NewsSearchResponse.builder()
+			.newsId(d.getNewsId())
+			.title(d.getTitle())
+			.content(d.getContent())
+			.publishedAt(d.getPublishedAt())
+			.imageUrl(d.getImageUrl())
+			.category(d.getCategory())
+			.build();
+	}
+
+	/**
+	 * 도메인 모델 리스트를 응답 DTO 리스트로 변환한다.
+	 *
+	 * @param domainList 변환할 도메인 모델 리스트
+	 * @return 응답 DTO 리스트가 포함된 NewsSearchResponseList
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	public static NewsSearchResponseList toListResponse(List<NewsSearchResult> domainList) {
+		List<NewsSearchResponse> items = domainList.stream()
+			.map(NewsSearchResponseMapper::toResponse)
+			.collect(Collectors.toList());
+		return NewsSearchResponseList.builder()
+			.newsSearchResponseList(items)
+			.total(items.size())
+			.build();
+	}
+}
+

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/port/out/NewsSearchRepositoryPort.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/port/out/NewsSearchRepositoryPort.java
@@ -1,0 +1,23 @@
+package com.likelion.backendplus4.talkpick.backend.search.application.port.out;
+
+import java.util.List;
+
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearch;
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearchResult;
+
+/**
+ * 뉴스 검색 저장소에 대한 포트 인터페이스
+ *
+ * @since 2025-05-15
+ */
+public interface NewsSearchRepositoryPort {
+	/**
+	 * 검색어에 매칭되는 뉴스 결과를 조회한다.
+	 *
+	 * @param newsSearch 검색어 및 페이징 정보 도메인 모델
+	 * @return 뉴스 검색 도메인 결과 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	List<NewsSearchResult> searchByMatch(NewsSearch newsSearch);
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/service/NewsSearchService.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/application/service/NewsSearchService.java
@@ -1,0 +1,41 @@
+package com.likelion.backendplus4.talkpick.backend.search.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.likelion.backendplus4.talkpick.backend.common.annotation.logging.EntryExitLog;
+import com.likelion.backendplus4.talkpick.backend.common.annotation.logging.LogMethodValues;
+import com.likelion.backendplus4.talkpick.backend.search.application.port.in.NewsSearchUseCase;
+import com.likelion.backendplus4.talkpick.backend.search.application.port.out.NewsSearchRepositoryPort;
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearch;
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearchResult;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 뉴스 검색 도메인 로직을 수행하는 서비스 구현체
+ *
+ * @since 2025-05-15
+ */
+@Service
+@RequiredArgsConstructor
+public class NewsSearchService implements NewsSearchUseCase {
+
+	private final NewsSearchRepositoryPort repository;
+
+	/**
+	 * 도메인 모델을 기반으로 저장소에서 검색 결과를 조회하여 반환한다.
+	 *
+	 * @param newsSearch 검색어 및 페이징 정보를 담은 도메인 모델
+	 * @return 검색된 뉴스 도메인 결과 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	@EntryExitLog
+	@LogMethodValues
+	@Override
+	public List<NewsSearchResult> searchByMatch(NewsSearch newsSearch) {
+		return repository.searchByMatch(newsSearch);
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/domain/model/NewsSearch.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/domain/model/NewsSearch.java
@@ -1,0 +1,43 @@
+package com.likelion.backendplus4.talkpick.backend.search.domain.model;
+
+import com.likelion.backendplus4.talkpick.backend.search.exception.SearchException;
+import com.likelion.backendplus4.talkpick.backend.search.exception.error.SearchErrorCode;
+
+import lombok.Getter;
+
+/**
+ * 뉴스 검색 시 전달되는 검색어와 페이징 정보를 검증 및 저장하는 도메인 모델
+ *
+ * @since 2025-05-15
+ */
+@Getter
+public class NewsSearch {
+	private final String query;
+	private final int page;
+	private final int size;
+
+	/**
+	 * 검색어, 페이지, 사이즈 유효성을 검증하면서 인스턴스를 생성한다.
+	 *
+	 * @param query 검색어 문자열
+	 * @param page  조회할 페이지 번호 (0 이상)
+	 * @param size  페이지당 결과 개수 (1 이상)
+	 * @throws SearchException 유효하지 않은 파라미터일 경우
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	public NewsSearch(String query, int page, int size) {
+		if (query == null || query.isBlank()) {
+			throw new SearchException(SearchErrorCode.INVALID_QUERY);
+		}
+		if (page < 0) {
+			throw new SearchException(SearchErrorCode.INVALID_PAGE);
+		}
+		if (size <= 0) {
+			throw new SearchException(SearchErrorCode.INVALID_SIZE);
+		}
+		this.query = query;
+		this.page = page;
+		this.size = size;
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/domain/model/NewsSearchResult.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/domain/model/NewsSearchResult.java
@@ -1,0 +1,22 @@
+package com.likelion.backendplus4.talkpick.backend.search.domain.model;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 검색된 뉴스 결과를 표현하는 도메인 모델
+ *
+ * @since 2025-05-15
+ */
+@Getter
+@Builder
+public class NewsSearchResult {
+	private final String newsId;
+	private final String title;
+	private final String content;
+	private final String imageUrl;
+	private final String category;
+	private final LocalDateTime publishedAt;
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/exception/SearchException.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/exception/SearchException.java
@@ -1,0 +1,18 @@
+package com.likelion.backendplus4.talkpick.backend.search.exception;
+
+import com.likelion.backendplus4.talkpick.backend.common.exception.CustomException;
+import com.likelion.backendplus4.talkpick.backend.common.exception.error.ErrorCode;
+
+public class SearchException extends CustomException {
+	private final ErrorCode errorCode;
+
+	public SearchException(ErrorCode errorCode) {
+		super(errorCode);
+		this.errorCode = errorCode;
+	}
+
+	@Override
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/exception/error/SearchErrorCode.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/exception/error/SearchErrorCode.java
@@ -1,0 +1,63 @@
+package com.likelion.backendplus4.talkpick.backend.search.exception.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.likelion.backendplus4.talkpick.backend.common.exception.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+/**
+ * 에러 코드 인터페이스 각 에러 항목에 대한 HTTP 상태, 에러 번호, 메시지를 제공한다.
+ * A[BB][CCC]
+ * A (1자리) : 에러 심각도 (1~5)
+ * 1: 클라이언트 오류
+ * 2: 인증 관련 오류
+ * 3: 사용자 관련 오류
+ * 4: 서버 오류
+ * 5: 시스템 오류
+ *
+ * BB (2자리) : 도메인 코드
+ * 10: 사용자 관련 (ex: USER_NOT_FOUND)
+ * 20: 인증 관련 (ex: AUTHORIZATION_FAILED)
+ * 30: DB 관련 오류 (ex: DB_CONNECTION_FAILED)
+ * 40: API 관련 오류 (ex: API_TIMEOUT)
+ * 50: 시스템 오류 (ex: INTERNAL_SERVER_ERROR)
+ *
+ * CCC (3자리) : 세부 오류 순번
+ * 001: 첫 번째 오류
+ * 002: 두 번째 오류
+ * 003: 세 번째 오류, 등등
+ *
+ * @modified 2025-04-18
+ * @since 2025-04-16
+ */
+@RequiredArgsConstructor
+public enum SearchErrorCode implements ErrorCode {
+    INVALID_QUERY(HttpStatus.BAD_REQUEST, 140001, "검색어를 입력해주세요"),
+    INVALID_PAGE(HttpStatus.BAD_REQUEST, 140002, "페이지 번호는 0 이상이어야 합니다."),
+    INVALID_SIZE(HttpStatus.BAD_REQUEST, 140003, "페이지 크기는 1 이상이어야 합니다."),
+    INVALID_SEARCH_TYPE(HttpStatus.BAD_REQUEST, 140004, "지원하지 않는 검색 타입입니다."),
+    ES_SEARCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 430001, "Elasticsearch 검색 실패"),
+    RDB_SEARCH_ERROR(HttpStatus.NO_CONTENT, 430002, "검색 결과가 없습니다"),
+    EMBEDDING_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 440001, "임베딩 API 호출 실패"),
+    ES_SUGGEST_SEARCH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 440002, "검색어 자동완성에 실패했습니다."),
+    ES_SEARCH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 440003, "증상 검색에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return status;
+    }
+
+    @Override
+    public int codeNumber() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/infrastructure/adapter/ElasticsearchNewsSearchAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/infrastructure/adapter/ElasticsearchNewsSearchAdapter.java
@@ -1,0 +1,122 @@
+package com.likelion.backendplus4.talkpick.backend.search.infrastructure.adapter;
+
+import static co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.*;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.stereotype.Component;
+
+import com.likelion.backendplus4.talkpick.backend.common.annotation.logging.EntryExitLog;
+import com.likelion.backendplus4.talkpick.backend.common.annotation.logging.LogMethodValues;
+import com.likelion.backendplus4.talkpick.backend.search.application.port.out.NewsSearchRepositoryPort;
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearch;
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearchResult;
+import com.likelion.backendplus4.talkpick.backend.search.infrastructure.adapter.document.NewsSearchDocument;
+import com.likelion.backendplus4.talkpick.backend.search.infrastructure.adapter.mapper.NewsSearchDocumentMapper;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+
+/**
+ * Elasticsearch를 사용해 뉴스 검색 도메인의 searchByMatch를 구현하는 어댑터 클래스
+ *
+ * @since 2025-05-15
+ */
+@Component
+public class ElasticsearchNewsSearchAdapter implements NewsSearchRepositoryPort {
+
+	private final ElasticsearchOperations ops;
+	private final NewsSearchDocumentMapper mapper;
+	private final String indexName;
+
+	public ElasticsearchNewsSearchAdapter(
+		ElasticsearchOperations ops,
+		NewsSearchDocumentMapper mapper,
+		@Value("${news.index.name}") String indexName) {
+		this.ops = ops;
+		this.mapper = mapper;
+		this.indexName = indexName;
+	}
+
+	/**
+	 * 검색어와 페이징 정보가 담긴 NewsSearch 도메인 모델을 기반으로
+	 * Elasticsearch에서 문서를 조회하여 도메인 결과 리스트로 반환한다.
+	 *
+	 * @param newsSearch 검색 조건과 페이징 정보가 담긴 도메인 모델
+	 * @return 검색된 뉴스 도메인 결과 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	@EntryExitLog
+	@LogMethodValues
+	@Override
+	public List<NewsSearchResult> searchByMatch(NewsSearch newsSearch) {
+		NativeQuery query = buildNativeQuery(newsSearch);
+		SearchHits<NewsSearchDocument> hits = executeSearch(query);
+		return mapToDomain(hits);
+	}
+
+	/**
+	 * 검색 조건에 맞는 Bool 쿼리를 생성하여 NativeQuery로 빌드한다.
+	 *
+	 * @param newsSearch 검색 조건과 페이징 정보 도메인 모델
+	 * @return Elasticsearch NativeQuery 객체
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	private NativeQuery buildNativeQuery(NewsSearch newsSearch) {
+		Query titleClause = match(m -> m
+			.field("title")
+			.analyzer("nori")
+			.query(newsSearch.getQuery())
+		);
+		Query contentClause = match(m -> m
+			.field("content")
+			.analyzer("nori")
+			.query(newsSearch.getQuery())
+		);
+		Query boolQuery = bool(b -> b
+			.should(titleClause)
+			.should(contentClause)
+		);
+		return NativeQuery.builder()
+			.withQuery(boolQuery)
+			.withPageable(PageRequest.of(newsSearch.getPage(), newsSearch.getSize()))
+			.build();
+	}
+
+	/**
+	 * NativeQuery를 실행하여 SearchHits 결과를 반환한다.
+	 *
+	 * @param query 실행할 NativeQuery 객체
+	 * @return 검색된 SearchHits 결과
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	private SearchHits<NewsSearchDocument> executeSearch(NativeQuery query) {
+		return ops.search(
+			query,
+			NewsSearchDocument.class,
+			IndexCoordinates.of(indexName)
+		);
+	}
+
+	/**
+	 * SearchHits에서 도메인 결과로 매핑하여 리스트로 변환한다.
+	 *
+	 * @param hits Elasticsearch SearchHits 결과
+	 * @return 매핑된 뉴스 도메인 결과 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	private List<NewsSearchResult> mapToDomain(SearchHits<NewsSearchDocument> hits) {
+		return hits.get()
+			.map(hit -> mapper.toDomain(hit.getContent()))
+			.toList();
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/infrastructure/adapter/document/NewsSearchDocument.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/infrastructure/adapter/document/NewsSearchDocument.java
@@ -1,0 +1,32 @@
+package com.likelion.backendplus4.talkpick.backend.search.infrastructure.adapter.document;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Elasticsearch news_index 인덱스에 매핑되는 문서 모델 클래스
+ *
+ * @since 2025-05-15
+ */
+@Document(indexName = "news_index")
+@Getter
+@Setter
+public class NewsSearchDocument {
+	@Id
+	private String newsId;
+	private String title;
+	private String content;
+	@Field(type = FieldType.Date, format = { DateFormat.epoch_millis })
+	private Instant publishedAt;
+	private String imageUrl;
+	private String category;
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/infrastructure/adapter/mapper/NewsSearchDocumentMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/infrastructure/adapter/mapper/NewsSearchDocumentMapper.java
@@ -1,0 +1,41 @@
+package com.likelion.backendplus4.talkpick.backend.search.infrastructure.adapter.mapper;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.springframework.stereotype.Component;
+
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearchResult;
+import com.likelion.backendplus4.talkpick.backend.search.infrastructure.adapter.document.NewsSearchDocument;
+
+/**
+ * Elasticsearch 문서 모델을 뉴스 검색 도메인 모델로 변환하는 매퍼
+ *
+ * @since 2025-05-15
+ */
+@Component
+public class NewsSearchDocumentMapper {
+	/**
+	 * 문서 모델의 Instant 타입 publishedAt을 LocalDateTime으로 변환하여 도메인 모델 생성
+	 *
+	 * @param doc Elasticsearch 문서 모델 객체
+	 * @return 변환된 뉴스 검색 도메인 결과
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	public NewsSearchResult toDomain(NewsSearchDocument doc) {
+		// Instant → LocalDateTime 변환
+		LocalDateTime ldt = LocalDateTime.ofInstant(
+			doc.getPublishedAt(),
+			ZoneId.systemDefault()
+		);
+		return NewsSearchResult.builder()
+			.newsId(doc.getNewsId())
+			.title(doc.getTitle())
+			.content(doc.getContent())
+			.publishedAt(ldt)
+			.imageUrl(doc.getImageUrl())
+			.category(doc.getCategory())
+			.build();
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/presentation/controller/NewsSearchController.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/presentation/controller/NewsSearchController.java
@@ -1,0 +1,52 @@
+package com.likelion.backendplus4.talkpick.backend.search.presentation.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion.backendplus4.talkpick.backend.common.annotation.logging.EntryExitLog;
+import com.likelion.backendplus4.talkpick.backend.common.annotation.logging.LogJson;
+import com.likelion.backendplus4.talkpick.backend.common.response.ApiResponse;
+import com.likelion.backendplus4.talkpick.backend.search.application.port.in.NewsSearchUseCase;
+import com.likelion.backendplus4.talkpick.backend.search.application.port.in.mapper.NewsSearchRequestMapper;
+import com.likelion.backendplus4.talkpick.backend.search.application.port.in.mapper.NewsSearchResponseMapper;
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearch;
+import com.likelion.backendplus4.talkpick.backend.search.domain.model.NewsSearchResult;
+import com.likelion.backendplus4.talkpick.backend.search.presentation.controller.dto.request.NewsSearchRequest;
+import com.likelion.backendplus4.talkpick.backend.search.presentation.controller.dto.response.NewsSearchResponseList;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 뉴스 검색 기능을 제공하는 REST 컨트롤러
+ *
+ * @since 2025-05-15
+ */
+@RestController
+@RequestMapping("/news")
+@RequiredArgsConstructor
+public class NewsSearchController {
+
+	private final NewsSearchUseCase searchUseCase;
+
+	/**
+	 * 검색 요청에 따라 뉴스를 조회하고 결과를 반환한다.
+	 *
+	 * @param request 검색어 및 페이지 정보가 담긴 요청 DTO
+	 * @return ApiResponse에 래핑된 검색 결과 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	@LogJson
+	@EntryExitLog
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<NewsSearchResponseList>> search(NewsSearchRequest request) {
+		NewsSearch newsSearch = NewsSearchRequestMapper.toDomain(request);
+		List<NewsSearchResult> newsSearchResultList = searchUseCase.searchByMatch(newsSearch);
+
+		return ApiResponse.success(NewsSearchResponseMapper.toListResponse(newsSearchResultList));
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/presentation/controller/dto/request/NewsSearchRequest.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/presentation/controller/dto/request/NewsSearchRequest.java
@@ -1,0 +1,17 @@
+package com.likelion.backendplus4.talkpick.backend.search.presentation.controller.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 뉴스 검색 시 필요한 검색어와 페이지 정보를 담는 요청 DTO
+ *
+ * @since 2025-05-15
+ */
+@RequiredArgsConstructor
+@Getter
+public class NewsSearchRequest {
+	private final String q;
+	private final int  page = 0;
+	private final int  size = 10;
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/presentation/controller/dto/response/NewsSearchResponse.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/presentation/controller/dto/response/NewsSearchResponse.java
@@ -1,0 +1,24 @@
+package com.likelion.backendplus4.talkpick.backend.search.presentation.controller.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 단일 뉴스 검색 결과를 나타내는 응답 DTO
+ *
+ * @since 2025-05-15
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class NewsSearchResponse {
+	private final String newsId;
+	private final String title;
+	private final String content;
+	private final LocalDateTime publishedAt;
+	private final String imageUrl;
+	private final String category;
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/search/presentation/controller/dto/response/NewsSearchResponseList.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/search/presentation/controller/dto/response/NewsSearchResponseList.java
@@ -1,0 +1,20 @@
+package com.likelion.backendplus4.talkpick.backend.search.presentation.controller.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 뉴스 검색 결과 목록과 총 개수를 담는 응답 DTO
+ *
+ * @since 2025-05-15
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class NewsSearchResponseList {
+	private final List<NewsSearchResponse> newsSearchResponseList;
+	private final int total;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,7 @@ log:
 
 jwt:
   secret: ${JWT_SECRET}
+
+news:
+  index:
+    name: news_index


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)

- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결

## ✨ 변경 사항
- ElasticsearchNewsSearchAdapter 추가
- buildNativeQuery(), executeSearch(), mapToDomain()으로 책임 분리
- NativeQuery + Nori analyzer 기반 match 쿼리(title/content) 구현

## 🔍 리뷰어에게

- Adapter의 메서드 분리 및 네이밍이 명확한지
- Nori 분석기 설정 및 쿼리 빌드 로직 검토
- DTO ↔ 도메인 매핑 매퍼 구현 확인 부탁드립니다

## ✅ PR 체크리스트

- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.

## 🔗 관련 이슈
closed #7 