### PR TITLE
✨ Feature/#71 페이지 응답 데이터 클래스 추가

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/response/SliceResponse.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/response/SliceResponse.java
@@ -1,0 +1,8 @@
+package com.likelion.backendplus4.talkpick.backend.common.response;
+
+import java.util.List;
+
+public record SliceResponse<T>(
+	List<T> items,
+	boolean hasNext) {
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/response/SliceResponse.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/response/SliceResponse.java
@@ -1,7 +1,12 @@
 package com.likelion.backendplus4.talkpick.backend.common.response;
 
 import java.util.List;
-
+/**
+ * 페이징 처리된 데이터 응답을 나타내는 제네릭 레코드 클래스.
+ *
+ * @param <T> 응답 항목의 타입
+ * @since 2025-05-18
+ */
 public record SliceResponse<T>(
 	List<T> items,
 	boolean hasNext) {

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/adapter/dto/SliceResult.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/adapter/dto/SliceResult.java
@@ -2,6 +2,12 @@ package com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.
 
 import java.util.List;
 
+/**
+ * 페이징 처리 결과를 담는 제네릭 레코드 클래스.
+ *
+ * @param <T> 결과 항목의 타입
+ * @since 2025-05-18
+ */
 public record SliceResult<T>(
 	List<T> content,
 	boolean hasNext

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/adapter/dto/SliceResult.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/adapter/dto/SliceResult.java
@@ -1,0 +1,8 @@
+package com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.adapter.dto;
+
+import java.util.List;
+
+public record SliceResult<T>(
+	List<T> content,
+	boolean hasNext
+) {}


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 페이지 단위로 응답을 제공할 때, Page 단위 응답 클래스가 필요해서 추가했습니다.
- 앞으로 페이지 단위 응답은 ApiResponse 안의 data필드를 SliceResponse으로 사용하는 방식으로 구현할 예정입니다. 
- Infra-JPA 의 경우에는 SliceResult 객체를 사용할 예정입니다.

## 🔍 리뷰어에게
- 무한 스크롤을 사용한다고 고려해서.. slice로 설계했는데, 만약 Page단위가 필요하면 응답도 Page로 수정하겠습니다.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #71 