### PR TITLE
🐛  Fix: 뉴스 상세 조회 오류 수정 및 웹소켓 인증 우회

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/configuration/security/SecurityConfig.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -102,6 +103,7 @@ public class SecurityConfig {
                 authorizationManagerRequestMatcherRegistry
                     .requestMatchers("/auth/**").permitAll()
                     .requestMatchers("/public/**").permitAll()
+                    .requestMatchers("/ws-chat/**").permitAll() // TODO: 웹소켓 인증관련 설정 시 수정
                     .requestMatchers("/user/**").hasRole(Role.USER.getRoleName())
                     .requestMatchers("/admin/**").hasRole(Role.ADMIN.getRoleName())
                     .anyRequest().authenticated())

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/entity/ArticleEntity.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/entity/ArticleEntity.java
@@ -69,7 +69,7 @@ public class ArticleEntity {
     private String summary;
 
     @Column(name = "summary_vector", columnDefinition = "JSON")
-    private float[] summaryVector;
+    private String summaryVector;
 
     @Setter
     @Column(name = "view_count", nullable = false)


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 뉴스 받아오는 과정에서 오류나서 봤더니… float[] 형으로 되어있어서 오류발생 → string으로 변환 하였습니다.
- +) 채팅 웹 소켓 연결을 위해 임시로 /ws-chat 도 permitAll()로 풀어두었습니다.


## 🔍 리뷰어에게
- 리뷰어가 집중해서 봐야 할 포인트가 있다면 알려주세요.
- 추가 설명이 필요한 부분이 있다면 작성해주세요.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #92 