### PR TITLE
🐛 Fix: 최신 뉴스 페이징 오류 수정

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/port/in/NewsInfoProviderUseCase.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/port/in/NewsInfoProviderUseCase.java
@@ -5,5 +5,5 @@ import com.likelion.backendplus4.talkpick.backend.news.info.domain.model.NewsInf
 import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.adapter.dto.SliceResult;
 
 public interface NewsInfoProviderUseCase {
-	SliceResult<NewsInfo> getLatestNewsInfo(Long lastIndex, int pageSize);
+	SliceResult<NewsInfo> getLatestNewsInfo(int page, int pageSize);
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/port/out/NewsInfoProviderPort.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/port/out/NewsInfoProviderPort.java
@@ -4,7 +4,5 @@ import com.likelion.backendplus4.talkpick.backend.news.info.domain.model.NewsInf
 import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.adapter.dto.SliceResult;
 
 public interface NewsInfoProviderPort {
-	SliceResult<NewsInfo> getLatestNewsInfo(int limit);
-
-	SliceResult<NewsInfo> getLatestNewsInfo(Long lastId, int limit);
+	SliceResult<NewsInfo> getLatestNewsInfo(int page, int limit);
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/service/NewsInfoProviderService.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/service/NewsInfoProviderService.java
@@ -16,10 +16,7 @@ public class NewsInfoProviderService implements NewsInfoProviderUseCase {
 	private static final int FIRST_PAGE_INDEX = -1;
 
 	@Override
-	public SliceResult<NewsInfo> getLatestNewsInfo(Long lastIndex, int pageSize) {
-		if(lastIndex == FIRST_PAGE_INDEX) {
-			return newsInfoProviderPort.getLatestNewsInfo(pageSize);
-		}
-		return newsInfoProviderPort.getLatestNewsInfo(lastIndex, pageSize);
+	public SliceResult<NewsInfo> getLatestNewsInfo(int page, int pageSize) {
+		return newsInfoProviderPort.getLatestNewsInfo(page, pageSize);
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
@@ -22,30 +22,18 @@ public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
 	private final NewsInfoJpaRepository newsInfoJpaRepository;
 
 	@Override
-	public SliceResult<NewsInfo> getLatestNewsInfo(int limit) {
-		return getFirstPageArticles(createPageable(limit));
+	public SliceResult<NewsInfo> getLatestNewsInfo(int page, int limit) {
+		return getArticles(createPageable(page, limit));
 	}
 
-	@Override
-	public SliceResult<NewsInfo> getLatestNewsInfo(Long lastId, int limit) {
-		return getNextPageArticles(lastId, createPageable(limit));
-	}
-	
-	private Pageable createPageable(int limit) {
-		Sort sortType = SortBuilder.createSortByIdDesc();
-		return PageableBuilder.createPageable(0, limit, sortType);
-	}
-
-	private SliceResult<NewsInfo> getFirstPageArticles(Pageable pageable) {
-		Slice<NewsInfo> slice =
-			newsInfoJpaRepository.findAll(pageable)
-				.map(ArticleEntityMapper::toInfoFromEntity);
-		return SliceResultBuilder.createSliceResult(slice);
-	}
-
-	private SliceResult<NewsInfo> getNextPageArticles(Long lastId, Pageable pageable) {
-		Slice<NewsInfo> slice = newsInfoJpaRepository.findByIdLessThanOrderByIdDesc(lastId, pageable)
+	private SliceResult<NewsInfo> getArticles(Pageable pageable) {
+		Slice<NewsInfo> slice = newsInfoJpaRepository.findAll(pageable)
 			.map(ArticleEntityMapper::toInfoFromEntity);
 		return SliceResultBuilder.createSliceResult(slice);
+	}
+
+	private Pageable createPageable(int page, int limit) {
+		Sort sortType = SortBuilder.createSortByIdDesc();
+		return PageableBuilder.createPageable(page, limit, sortType);
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/repository/NewsInfoJpaRepository.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/repository/NewsInfoJpaRepository.java
@@ -29,14 +29,4 @@ public interface NewsInfoJpaRepository extends JpaRepository<ArticleEntity, Long
 	 */
 	List<ArticleEntity> findByGuid(String guid);
 
-	/**
-	 * 지정된 ID보다 작은 ID를 가진 ArticleEntity들을 ID 내림차순으로 조회합니다.
-	 *
-	 * @param lastId 기준이 되는 마지막 Article ID (미포함)
-	 * @param pageable 페이지 정보 (페이지 크기 및 정렬 정보 포함)
-	 * @return 조건에 맞는 ArticleEntity 목록의 슬라이스
-	 * @author 함예정
-	 * @since 2025-05-19
-	 */
-	Slice<ArticleEntity> findByIdLessThanOrderByIdDesc(Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/NewsInfoProviderController.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/NewsInfoProviderController.java
@@ -31,7 +31,7 @@ public class NewsInfoProviderController {
 	public ResponseEntity<ApiResponse<SliceResponse>> getLatestNewsInfo(
 		NewsInfoRequest newsInfoRequest) {
 		SliceResult<NewsInfo> latestNewsInfos =
-			newsInfoProviderUsecase.getLatestNewsInfo(newsInfoRequest.page()-1, newsInfoRequest.size());
+			newsInfoProviderUsecase.getLatestNewsInfo(newsInfoRequest.page(), newsInfoRequest.size());
 
 		return success(NewsInfoResponseMapper.toSliceResponse(latestNewsInfos));
 	}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/NewsInfoProviderController.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/NewsInfoProviderController.java
@@ -15,8 +15,10 @@ import com.likelion.backendplus4.talkpick.backend.common.response.SliceResponse;
 import com.likelion.backendplus4.talkpick.backend.news.info.application.port.in.NewsInfoProviderUseCase;
 import com.likelion.backendplus4.talkpick.backend.news.info.domain.model.NewsInfo;
 import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.adapter.dto.SliceResult;
+import com.likelion.backendplus4.talkpick.backend.news.info.presentation.controller.dto.NewsInfoRequest;
 import com.likelion.backendplus4.talkpick.backend.news.info.presentation.mapper.NewsInfoResponseMapper;
 
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,10 +29,9 @@ public class NewsInfoProviderController {
 
 	@GetMapping("/latest")
 	public ResponseEntity<ApiResponse<SliceResponse>> getLatestNewsInfo(
-		@RequestParam(defaultValue = "-1") Long last,
-		@RequestParam int size) {
+		NewsInfoRequest newsInfoRequest) {
 		SliceResult<NewsInfo> latestNewsInfos =
-			newsInfoProviderUsecase.getLatestNewsInfo(last, size);
+			newsInfoProviderUsecase.getLatestNewsInfo(newsInfoRequest.page()-1, newsInfoRequest.size());
 
 		return success(NewsInfoResponseMapper.toSliceResponse(latestNewsInfos));
 	}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/dto/NewsInfoRequest.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/dto/NewsInfoRequest.java
@@ -1,0 +1,5 @@
+package com.likelion.backendplus4.talkpick.backend.news.info.presentation.controller.dto;
+
+public record NewsInfoRequest(
+	int page, int size) {
+}


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 최신 뉴스를 가져올 때, last ID와 page size로 요청하는 기존 로직을 수정했습니다.
- 관리형 필드인 ID 값을 frontend에서 확인할 수 없어 이를 page 번호로 수정했습니다.
- RequestParam으로 받아오던 값을 객체로 받아오도록 수정하였습니다 (@ModelAttribute 어노테이션 생략)

## 🔍 리뷰어에게
- 잘못된 부분이 있거나 구현상 더 나은 방법이 있으면 추천해주세요


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #100 