### PR TITLE
Feature/#109 카테고리별 뉴스 조회

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/port/in/NewsInfoProviderUseCase.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/port/in/NewsInfoProviderUseCase.java
@@ -1,10 +1,37 @@
 package com.likelion.backendplus4.talkpick.backend.news.info.application.port.in;
 
-import com.likelion.backendplus4.talkpick.backend.news.info.application.dto.NewsInfoDetailResponse;
 import com.likelion.backendplus4.talkpick.backend.news.info.domain.model.NewsInfo;
 import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.adapter.dto.SliceResult;
 
+/**
+ * 뉴스 정보를 조회하기 위한 유스케이스 인터페이스
+ * 최신 뉴스 정보 및 카테고리별 최신 뉴스 정보를 슬라이스 방식으로 제공한다.
+ *
+ * @since 2025-05-16
+ * @modified 2025-05-26
+ */
 public interface NewsInfoProviderUseCase {
+
+	/**
+	 * 최신 뉴스 정보를 마지막 ID 기준으로 페이지 단위로 조회한다.
+	 *
+	 * @param lastId 마지막으로 조회된 뉴스 ID (null일 경우 처음부터 조회)
+	 * @param pageSize 한 페이지에 포함될 뉴스 개수
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-16
+	 */
 	SliceResult<NewsInfo> getLatestNewsInfo(String lastId, int pageSize);
+
+	/**
+	 * 카테고리별 최신 뉴스 정보를 마지막 ID 기준으로 페이지 단위로 조회한다.
+	 *
+	 * @param category 뉴스 카테고리
+	 * @param lastId 마지막으로 조회된 뉴스 ID (null일 경우 처음부터 조회)
+	 * @param pageSize 한 페이지에 포함될 뉴스 개수
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	SliceResult<NewsInfo> getLatestNewsInfoByCategory(String category, String lastId, int pageSize);
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/port/out/NewsInfoProviderPort.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/port/out/NewsInfoProviderPort.java
@@ -3,8 +3,35 @@ package com.likelion.backendplus4.talkpick.backend.news.info.application.port.ou
 import com.likelion.backendplus4.talkpick.backend.news.info.domain.model.NewsInfo;
 import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.adapter.dto.SliceResult;
 
+/**
+ * 뉴스 정보를 외부 저장소(JPA, API 등)로부터 조회하기 위한 포트 인터페이스.
+ * 최신 뉴스 정보 및 카테고리별 뉴스 정보를 슬라이스 방식으로 제공한다.
+ *
+ * @since 2025-05-16
+ * @modified 2025-05-26
+ */
 public interface NewsInfoProviderPort {
+
+	/**
+	 * 최신 뉴스 정보를 마지막 뉴스 ID를 기준으로 제한된 개수만큼 조회한다.
+	 *
+	 * @param lastNewsId 마지막으로 조회된 뉴스 ID (null일 경우 처음부터 조회)
+	 * @param limit 조회할 뉴스 개수 제한
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-16
+	 */
 	SliceResult<NewsInfo> getLatestNewsInfo(String lastNewsId, int limit);
 
+	/**
+	 * 지정한 카테고리에 해당하는 최신 뉴스 정보를 마지막 뉴스 ID를 기준으로 제한된 개수만큼 조회한다.
+	 *
+	 * @param category 뉴스 카테고리
+	 * @param lastNewsId 마지막으로 조회된 뉴스 ID (null일 경우 처음부터 조회)
+	 * @param limit 조회할 뉴스 개수 제한
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	SliceResult<NewsInfo> getLatestNewsInfoByCategory(String category, String lastNewsId, int limit);
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/service/NewsInfoProviderService.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/service/NewsInfoProviderService.java
@@ -9,16 +9,46 @@ import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.a
 
 import lombok.RequiredArgsConstructor;
 
+
+/**
+ * 뉴스 정보 조회 기능을 제공하는 서비스 클래스.
+ * NewsInfoProviderUseCase를 구현하여 외부 요청을 처리하며,
+ * 실제 데이터 조회는 NewsInfoProviderPort를 통해 수행된다.
+ *
+ * @since 2025-05-16
+ * @modified 2025-05-26
+ */
 @Service
 @RequiredArgsConstructor
 public class NewsInfoProviderService implements NewsInfoProviderUseCase {
 	private final NewsInfoProviderPort newsInfoProviderPort;
 
+	/**
+	 * 최신 뉴스 정보를 마지막 ID 기준으로 페이지 단위로 조회한다.
+	 *
+	 * @param lastId 마지막으로 조회된 뉴스 ID (null일 경우 처음부터 조회)
+	 * @param pageSize 한 페이지에 포함될 뉴스 개수
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-16
+	 * @modified 2025-05-26
+	 */
 	@Override
 	public SliceResult<NewsInfo> getLatestNewsInfo(String lastId, int pageSize) {
 		return newsInfoProviderPort.getLatestNewsInfo(lastId, pageSize);
 	}
 
+	/**
+	 * 지정한 카테고리의 최신 뉴스 정보를 마지막 ID 기준으로 페이지 단위로 조회한다.
+	 *
+	 * @param category 뉴스 카테고리
+	 * @param lastId 마지막으로 조회된 뉴스 ID (null일 경우 처음부터 조회)
+	 * @param pageSize 한 페이지에 포함될 뉴스 개수
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-16
+	 * @modified 2025-05-26
+	 */
 	@Override
 	public SliceResult<NewsInfo> getLatestNewsInfoByCategory(String category, String lastId, int pageSize) {
 		return newsInfoProviderPort.getLatestNewsInfoByCategory(category, lastId, pageSize);

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/exception/error/NewsInfoErrorCode.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/exception/error/NewsInfoErrorCode.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public enum NewsInfoErrorCode implements ErrorCode {
 	NON_UNIQUE_NEWS_INFO(HttpStatus.INTERNAL_SERVER_ERROR, 450001, "고유한 뉴스 ID 값이 아닙니다"),
 	NEWS_INFO_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, 450002, "뉴스 정보를 찾을수 없습니다"),
+	NEWS_CATEGORY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, 450003, "지원하지 않는 카테고리 입니다"),
 
 	// 조회수 관련 에러 코드
 	VIEW_COUNT_INVALID_FORMAT(HttpStatus.BAD_REQUEST, 450011, "조회수 값의 형식이 올바르지 않습니다"),

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
@@ -21,17 +21,33 @@ import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.s
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * NewsInfoProviderPort 구현체.
+ * JPA 기반으로 뉴스 정보를 조회하며, 슬라이스 방식의 페이지네이션과 카테고리 필터링 기능을 제공한다.
+ *
+ * @since 2025-05-16
+ * @modified 2025-05-26
+ */
 @Component
 @RequiredArgsConstructor
 public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
 	private final NewsInfoJpaRepository newsInfoJpaRepository;
 
-
+	/**
+	 * 마지막 뉴스 ID 기준으로 최신 뉴스 목록을 조회한다.
+	 *
+	 * @param lastNewsId 마지막 뉴스 ID (null이면 첫 페이지로 간주)
+	 * @param limit 조회할 뉴스 개수
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-16
+	 * @modified 2025-05-26
+	 */
 	@Override
 	public SliceResult<NewsInfo> getLatestNewsInfo(String lastNewsId, int limit) {
 		Pageable pageable = createPageable(limit);
 
-		if(lastNewsId == null){
+		if (lastNewsId == null) {
 			return getFirstArticles(pageable);
 		}
 
@@ -40,11 +56,22 @@ public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
 		return getLatestArticles(articleId, pageable);
 	}
 
+	/**
+	 * 마지막 뉴스 ID와 카테고리 기준으로 최신 뉴스 목록을 조회한다.
+	 *
+	 * @param inputCategory 입력된 카테고리명
+	 * @param lastNewsId 마지막 뉴스 ID (null이면 첫 페이지로 간주)
+	 * @param limit 조회할 뉴스 개수
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	@Override
 	public SliceResult<NewsInfo> getLatestNewsInfoByCategory(String inputCategory, String lastNewsId, int limit) {
 		Pageable pageable = createPageable(limit);
 		String category = NewsCategory.displayNameOf(inputCategory);
-		if(lastNewsId == null){
+
+		if (lastNewsId == null) {
 			return getFirstArticlesByCategory(category, pageable);
 		}
 
@@ -57,35 +84,78 @@ public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
 		return SliceResultBuilder.createSliceResult(slice);
 	}
 
+	/**
+	 * 첫 페이지의 뉴스 목록을 조회한다.
+	 *
+	 * @param pageable 페이지 정보
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	private SliceResult<NewsInfo> getFirstArticles(Pageable pageable) {
 		Slice<NewsInfo> slice = newsInfoJpaRepository.findAllByOrderByIdDesc(pageable)
 			.map(ArticleEntityMapper::toInfoFromEntity);
 		return SliceResultBuilder.createSliceResult(slice);
 	}
 
+	/**
+	 * 첫 페이지의 카테고리별 뉴스 목록을 조회한다.
+	 *
+	 * @param category 카테고리명
+	 * @param pageable 페이지 정보
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	private SliceResult<NewsInfo> getFirstArticlesByCategory(String category, Pageable pageable) {
 		Slice<NewsInfo> slice = newsInfoJpaRepository.findAllByCategoryOrderByIdDesc(category, pageable)
 			.map(ArticleEntityMapper::toInfoFromEntity);
 		return SliceResultBuilder.createSliceResult(slice);
 	}
 
+	/**
+	 * 마지막 뉴스 ID보다 작은 ID를 가진 최신 뉴스 목록을 조회한다.
+	 *
+	 * @param articleId 기준이 되는 뉴스 ID
+	 * @param pageable 페이지 정보
+	 * @return 뉴스 정보 슬라이스 결과
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	private SliceResult<NewsInfo> getLatestArticles(long articleId, Pageable pageable) {
 		Slice<NewsInfo> slice = newsInfoJpaRepository.findAllByIdLessThanOrderByIdDesc(articleId, pageable)
 			.map(ArticleEntityMapper::toInfoFromEntity);
 		return SliceResultBuilder.createSliceResult(slice);
 	}
 
+	/**
+	 * 정렬 기준을 포함한 Pageable 객체를 생성한다.
+	 *
+	 * @param limit 페이지 당 항목 수
+	 * @return Pageable 객체
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	private Pageable createPageable(int limit) {
 		Sort sortType = SortBuilder.createSortByIdDesc();
 		return PageableBuilder.createPageable(0, limit, sortType);
 	}
 
+	/**
+	 * 뉴스 ID(guid)를 기반으로 내부 article ID를 조회한다.
+	 *
+	 * @param newsId 뉴스 GUID
+	 * @return 내부 article ID
+	 * @throws NewsInfoException 뉴스 정보가 존재하지 않을 경우
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	private long getArticleIdByNewsId(String newsId) {
 		try {
 			return newsInfoJpaRepository.findByGuid(newsId)
 				.getFirst()
 				.getId();
-		} catch (NoSuchElementException e){
+		} catch (NoSuchElementException e) {
 			throw new NewsInfoException(NewsInfoErrorCode.NEWS_INFO_NOT_FOUND);
 		}
 	}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/entity/dto/NewsCategory.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/entity/dto/NewsCategory.java
@@ -1,5 +1,14 @@
 package com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.entity.dto;
 
+import com.likelion.backendplus4.talkpick.backend.news.info.exception.NewsInfoException;
+import com.likelion.backendplus4.talkpick.backend.news.info.exception.error.NewsInfoErrorCode;
+
+/**
+ * 뉴스 카테고리 열거형.
+ * 각 카테고리는 사용자에게 보여줄 표시 이름(displayName)을 가진다.
+ *
+ * @since 2025-05-26
+ */
 public enum NewsCategory {
 	POLITICS("정치"),
 	ECONOMY("경제"),
@@ -18,14 +27,23 @@ public enum NewsCategory {
 		return displayName;
 	}
 
-
+	/**
+	 * 카테고리 코드(String)를 받아 해당 열거형의 표시 이름을 반환한다.
+	 * 코드가 잘못된 경우 NewsInfoException 발생.
+	 *
+	 * @param code 카테고리 코드 (예: "politics", "ECONOMY")
+	 * @return 대응되는 카테고리의 표시 이름
+	 * @throws NewsInfoException 지원하지 않는 카테고리 코드일 경우
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	public static String displayNameOf(String code) {
 		try {
 			return NewsCategory
 				.valueOf(code.trim().toUpperCase())
 				.getDisplayName();
 		} catch (IllegalArgumentException | NullPointerException e) {
-			throw new IllegalArgumentException("지원하지 않는 카테고리 코드: " + code);
+			throw new NewsInfoException(NewsInfoErrorCode.NEWS_CATEGORY_NOT_FOUND);
 		}
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/mapper/ArticleEntityMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/mapper/ArticleEntityMapper.java
@@ -12,18 +12,18 @@ import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.jpa.e
 public class ArticleEntityMapper {
 	public static NewsInfoDetail toDetailFromEntity(ArticleEntity entity) {
 		return NewsInfoDetail.builder()
-				.newsId(entity.getGuid())
-				.title(entity.getTitle())
-				.originLink(entity.getLink())
-				.pubDate(entity.getPubDate())
-				.category(entity.getCategory())
-				.content(entity.getDescription())
-				.imageUrl(entity.getImageUrl())
-				.summary(entity.getSummary())
-				.viewCount(entity.getViewCount())
-				.build();
+			.newsId(entity.getGuid())
+			.title(entity.getTitle())
+			.originLink(entity.getLink())
+			.pubDate(entity.getPubDate())
+			.category(entity.getCategory())
+			.content(entity.getDescription())
+			.imageUrl(entity.getImageUrl())
+			.summary(entity.getSummary())
+			.viewCount(entity.getViewCount())
+			.build();
 	}
-	
+
 	public static NewsInfo toInfoFromEntity(ArticleEntity e) {
 		return NewsInfo.builder()
 			.id(e.getGuid())

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/repository/NewsInfoJpaRepository.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/jpa/repository/NewsInfoJpaRepository.java
@@ -29,22 +29,47 @@ public interface NewsInfoJpaRepository extends JpaRepository<ArticleEntity, Long
 	 */
 	List<ArticleEntity> findByGuid(String guid);
 
+	/**
+	 * 전체 뉴스 목록을 ID 내림차순으로 페이지네이션하여 조회합니다.
+	 *
+	 * @param pageable 페이지 정보
+	 * @return 뉴스 엔티티 슬라이스
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	Slice<ArticleEntity> findAllByOrderByIdDesc(Pageable pageable);
 
+	/**
+	 * 특정 카테고리의 뉴스 목록을 ID 내림차순으로 페이지네이션하여 조회합니다.
+	 *
+	 * @param category 뉴스 카테고리
+	 * @param pageable 페이지 정보
+	 * @return 뉴스 엔티티 슬라이스
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	Slice<ArticleEntity> findAllByCategoryOrderByIdDesc(String category, Pageable pageable);
 
+	/**
+	 * 지정된 ID보다 작은 ID를 가진 뉴스 목록을 ID 내림차순으로 조회합니다.
+	 *
+	 * @param id 기준이 되는 ID (미포함)
+	 * @param pageable 페이지 정보
+	 * @return 뉴스 엔티티 슬라이스
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	Slice<ArticleEntity> findAllByIdLessThanOrderByIdDesc(long id, Pageable pageable);
 
-	Slice<ArticleEntity> findAllByCategoryAndIdLessThanOrderByIdDesc(String category, Long id, Pageable pageable);
 	/**
-	 * 지정된 ID보다 작은 ID를 가진 ArticleEntity들을 ID 내림차순으로 조회합니다.
+	 * 특정 카테고리 내에서 지정된 ID보다 작은 ID를 가진 뉴스 목록을 ID 내림차순으로 조회합니다.
 	 *
-	 * @param lastId 기준이 되는 마지막 Article ID (미포함)
-	 * @param pageable 페이지 정보 (페이지 크기 및 정렬 정보 포함)
-	 * @return 조건에 맞는 ArticleEntity 목록의 슬라이스
+	 * @param category 뉴스 카테고리
+	 * @param id 기준이 되는 ID (미포함)
+	 * @param pageable 페이지 정보
+	 * @return 뉴스 엔티티 슬라이스
 	 * @author 함예정
-	 * @since 2025-05-19
+	 * @since 2025-05-26
 	 */
-	Slice<ArticleEntity> findByIdLessThanOrderByIdDesc(Long lastId, Pageable pageable);
-
+	Slice<ArticleEntity> findAllByCategoryAndIdLessThanOrderByIdDesc(String category, Long id, Pageable pageable);
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/NewsInfoProviderController.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/NewsInfoProviderController.java
@@ -18,12 +18,26 @@ import com.likelion.backendplus4.talkpick.backend.news.info.presentation.mapper.
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 뉴스 정보를 조회하는 공개 API 컨트롤러
+ * 최신 뉴스 및 카테고리별 최신 뉴스 리스트를 제공한다.
+ *
+ * @since 2025-05-16
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/public/news")
 public class NewsInfoProviderController {
 	private final NewsInfoProviderUseCase newsInfoProviderUsecase;
 
+	/**
+	 * 최신 뉴스 정보를 조회합니다.
+	 *
+	 * @param newsInfoRequest 마지막 뉴스 ID 및 조회 개수를 포함한 요청 파라미터
+	 * @return 뉴스 정보 목록을 포함한 응답
+	 * @author 함예정
+	 * @since 2025-05-16
+	 */
 	@GetMapping("/latest")
 	public ResponseEntity<ApiResponse<SliceResponse>> getLatestNewsInfo(
 		NewsInfoRequest newsInfoRequest) {
@@ -33,6 +47,14 @@ public class NewsInfoProviderController {
 		return success(NewsInfoResponseMapper.toSliceResponse(latestNewsInfos));
 	}
 
+	/**
+	 * 특정 카테고리의 최신 뉴스 정보를 조회합니다.
+	 *
+	 * @param newsInfoRequestByCategory 카테고리, 마지막 뉴스 ID, 조회 개수를 포함한 요청 파라미터
+	 * @return 카테고리별 뉴스 정보 목록을 포함한 응답
+	 * @author 함예정
+	 * @since 2025-05-26
+	 */
 	@GetMapping("/latest/category")
 	public ResponseEntity<ApiResponse<SliceResponse>> getLatestNewsInfoByCategory(
 		NewsInfoRequestByCategory newsInfoRequestByCategory) {

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/dto/NewsInfoRequest.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/dto/NewsInfoRequest.java
@@ -1,5 +1,9 @@
 package com.likelion.backendplus4.talkpick.backend.news.info.presentation.controller.dto;
-
+/**
+ * 뉴스 조회 요청 DTO
+ *
+ * @since 2025-05-26
+ */
 public record NewsInfoRequest(
 	String lastId,
 	Integer size) {

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/dto/NewsInfoRequestByCategory.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/presentation/controller/dto/NewsInfoRequestByCategory.java
@@ -1,5 +1,9 @@
 package com.likelion.backendplus4.talkpick.backend.news.info.presentation.controller.dto;
-
+/**
+ * 카테고리별 뉴스 조회 요청 DTO
+ *
+ * @since 2025-05-26
+ */
 public record NewsInfoRequestByCategory(
 	String lastId,
 	Integer size,


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 최근 뉴스를 가져올 때 lastNewsId를 받아오면 어댑터에서 DB에서 관리하는 ID값을 가져오고,
   이를 통해 최근 뉴스를 가져오도록 수정
- 카테고리 별로 최근 뉴스를 가져올 수 있도록 수정 ("/news/latest/category?category=politics")
- lastId가 null로 입력이 없으면 가장 최근 뉴스를 가져오도록 구현함


## 🔍 리뷰어에게
- 개선해야할 사항이 있으면 알려주세요 :)

## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #109 