### PR TITLE
✨ Feat: 캐싱 허용 Url 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,3 +99,7 @@ auth:
     field:
       email-auth-code: emailAuthCode
       account: account
+
+cache:
+  header: ${CACHE_HEADER:public, max-age=3600, must-revalidate}
+  prefix: ${CACHE_PREFIX:/public/}


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- `/public/**` 경로에 캐싱 허용 URL 추가
- 캐시 헤더를 하드코딩에서 `application.yml` 프로퍼티(`cache.public.header`)로 분리
- `SecurityConfig`의 `publicCacheWriter()` 메서드에서 주입된 `publicCacheControlHeader` 필드 사용하도록 수정

## 🔍 리뷰어에게
- 캐싱 허용 URL(`/public/**`)이 올바르게 적용되었는지 확인 부탁드립니다.
- `cache.public.header` 프로퍼티의 기본값 및 포맷이 적절한지 검토해주세요.
- `publicCacheWriter()` 메서드가 의도한 대로 `/public/**` 요청에만 헤더를 적용하는지 테스트로 검증해주세요.

## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #114 