### PR TITLE
news:ranking (랭킹용 redis 저장소) 데이터 저장방식 score방식으로 수정

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/redis/adapter/PopularNewsRedisAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/infrastructure/redis/adapter/PopularNewsRedisAdapter.java
@@ -21,7 +21,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * 인기뉴스 랭킹 관리를 담당하는 Redis 어댑터입니다.
  *
- * 뉴스 랭킹 조회, 해시값 관리, Top1 뉴스 캐싱 등의 기능을 제공합니다.
+ * Score 조합 방식: (viewCount × 100,000) + pubDate
+ * - 높은 조회수 우선, 같은 조회수 내에서는 최신 날짜 순
  *
  * @author 양병학
  * @since 2025-05-27 최초 작성
@@ -30,8 +31,9 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class PopularNewsRedisAdapter implements PopularNewsPort {
 
-    private final NewsDetailProviderPort newsDetailProviderPort;
+    private static final long VIEW_COUNT_MULTIPLIER = 100_000L;
 
+    private final NewsDetailProviderPort newsDetailProviderPort;
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisKeyGenerator keyGenerator;
     private final RedisJsonConverter jsonConverter;
@@ -42,8 +44,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
      * @param category 조회할 카테고리명
      * @return Top1 뉴스 ID, 없으면 null
      * @throws NewsInfoException Top1 뉴스 조회 중 오류가 발생한 경우
-     * @author 양병학
-     * @since 2025-05-27 최초 작성
      */
     @Override
     public String getTop1NewsId(String category) {
@@ -54,10 +54,8 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
      * 특정 카테고리의 Top1 뉴스와 점수를 조회합니다.
      *
      * @param category 조회할 카테고리명
-     * @return "뉴스ID:점수" 형태의 문자열, 없으면 "empty"
+     * @return "뉴스ID:점수" 형태의 문자열, 없으면 null
      * @throws NewsInfoException Top1 뉴스 조회 중 오류가 발생한 경우
-     * @author 양병학
-     * @since 2025-05-27 최초 작성
      */
     @Override
     public String getTop1NewsWithScore(String category) {
@@ -70,8 +68,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
      * @param category  카테고리명
      * @param hashValue 저장할 해시값
      * @throws NewsInfoException 해시값 저장 중 오류가 발생한 경우
-     * @author 양병학
-     * @since 2025-05-27 최초 작성
      */
     @Override
     public void saveRankingHash(String category, String hashValue) {
@@ -84,8 +80,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
      * @param category 조회할 카테고리명
      * @return 저장된 해시값
      * @throws NewsInfoException 해시값 조회 중 오류가 발생한 경우
-     * @author 양병학
-     * @since 2025-05-27 최초 작성
      */
     @Override
     public String getSavedRankingHash(String category) {
@@ -98,8 +92,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
      * @param category 카테고리명
      * @param topNews  저장할 뉴스 데이터
      * @throws NewsInfoException 캐시 저장 중 오류가 발생한 경우
-     * @author 양병학
-     * @since 2025-05-27 최초 작성
      */
     @Override
     public void saveTopNews(String category, PopularNewsResponse topNews) {
@@ -112,8 +104,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
      * @param category 조회할 카테고리명
      * @return 캐시된 뉴스 데이터, 없으면 null
      * @throws NewsInfoException 캐시 조회 중 오류가 발생한 경우
-     * @author 양병학
-     * @since 2025-05-27 최초 작성
      */
     @Override
     public PopularNewsResponse getTopNews(String category) {
@@ -122,22 +112,32 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
 
     /**
      * 랭킹 점수를 업데이트합니다.
+     * Score = (viewCount × 100,000) + pubDate
      *
-     * @param category  카테고리명
-     * @param newsId    뉴스 ID
-     * @param viewCount 조회수
+     * @param category    카테고리명
+     * @param newsId      뉴스 ID
+     * @param viewCount   조회수
+     * @param publishDate 발행일
      * @throws NewsInfoException 랭킹 업데이트 중 오류가 발생한 경우
      */
     public void updateRankingScore(String category, String newsId, Long viewCount, LocalDateTime publishDate) {
         performRankingScoreUpdate(category, newsId, viewCount, publishDate);
     }
 
+    @Override
+    public PopularNewsResponse getPopularNewsResponseById(String newsId) {
+        try {
+            NewsInfoDetail newsDetail = newsDetailProviderPort.getNewsInfoDetailsByArticleId(newsId);
+            return PopularNewsResponseMapper.toResponse(newsDetail);
+        } catch (Exception e) {
+            throw new NewsInfoException(NewsInfoErrorCode.NEWS_INFO_NOT_FOUND, e);
+        }
+    }
+
+    // ==================== Private Methods ====================
+
     /**
      * Top1 뉴스 ID를 조회합니다.
-     *
-     * @param category 카테고리명
-     * @return Top1 뉴스 ID
-     * @throws NewsInfoException 조회 실패 시
      */
     private String retrieveTop1NewsId(String category) {
         try {
@@ -151,16 +151,12 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
 
     /**
      * Top1 뉴스와 점수를 조회합니다.
-     *
-     * @param category 카테고리명
-     * @return "뉴스ID:점수" 형태의 문자열
-     * @throws NewsInfoException 조회 실패 시
      */
     private String retrieveTop1NewsWithScore(String category) {
         try {
             String rankingKey = keyGenerator.createRankingKey(category);
             Set<ZSetOperations.TypedTuple<String>> top1WithScore =
-                    redisTemplate.opsForZSet().reverseRangeWithScores(rankingKey, 0, 0);
+                redisTemplate.opsForZSet().reverseRangeWithScores(rankingKey, 0, 0);
 
             if (top1WithScore.isEmpty()) {
                 return null;
@@ -175,10 +171,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
 
     /**
      * 랭킹 해시값을 저장합니다.
-     *
-     * @param category  카테고리명
-     * @param hashValue 해시값
-     * @throws NewsInfoException 저장 실패 시
      */
     private void storeRankingHash(String category, String hashValue) {
         try {
@@ -191,10 +183,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
 
     /**
      * 저장된 랭킹 해시값을 조회합니다.
-     *
-     * @param category 카테고리명
-     * @return 해시값
-     * @throws NewsInfoException 조회 실패 시
      */
     private String retrieveSavedRankingHash(String category) {
         try {
@@ -207,10 +195,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
 
     /**
      * Top1 뉴스를 캐시에 저장합니다.
-     *
-     * @param category 카테고리명
-     * @param topNews  뉴스 데이터
-     * @throws NewsInfoException 저장 실패 시
      */
     private void storeTopNewsToCache(String category, PopularNewsResponse topNews) {
         try {
@@ -225,10 +209,6 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
 
     /**
      * 캐시에서 Top1 뉴스를 조회합니다.
-     *
-     * @param category 카테고리명
-     * @return 뉴스 데이터
-     * @throws NewsInfoException 조회 실패 시
      */
     private PopularNewsResponse retrieveTopNewsFromCache(String category) {
         try {
@@ -247,29 +227,30 @@ public class PopularNewsRedisAdapter implements PopularNewsPort {
 
     /**
      * 랭킹 점수를 업데이트합니다.
-     *
-     * @param category  카테고리명
-     * @param newsId    뉴스 ID
-     * @param viewCount 조회수
-     * @throws NewsInfoException 업데이트 실패 시
+     * Score = (viewCount × 100,000) + pubDate
      */
     private void performRankingScoreUpdate(String category, String newsId, Long viewCount, LocalDateTime publishDate) {
         try {
-            String rankingKey = keyGenerator.createRankingKey(category, publishDate);
-            redisTemplate.opsForZSet().add(rankingKey, newsId, viewCount.doubleValue());
-            redisTemplate.expire(rankingKey, 3, TimeUnit.DAYS);
+            String rankingKey = keyGenerator.createRankingKey(category);
+            double score = calculateScore(publishDate, viewCount);
+
+            redisTemplate.opsForZSet().add(rankingKey, newsId, score);
+            redisTemplate.expire(rankingKey, 30, TimeUnit.DAYS);
         } catch (Exception e) {
             throw new NewsInfoException(NewsInfoErrorCode.RANKING_SCORE_UPDATE_FAILED, e);
         }
     }
 
-    @Override
-    public PopularNewsResponse getPopularNewsResponseById(String newsId) {
-        try {
-            NewsInfoDetail newsDetail = newsDetailProviderPort.getNewsInfoDetailsByArticleId(newsId);
-            return PopularNewsResponseMapper.toResponse(newsDetail);
-        } catch (Exception e) {
-            throw new NewsInfoException(NewsInfoErrorCode.NEWS_INFO_NOT_FOUND, e);
-        }
+    /**
+     * Score를 계산합니다.
+     * Score = (viewCount × 100,000) + pubDate
+     *
+     * @param publishDate 발행일
+     * @param viewCount   조회수
+     * @return 계산된 Score
+     */
+    private double calculateScore(LocalDateTime publishDate, Long viewCount) {
+        long pubDateValue = publishDate.toLocalDate().toEpochDay();
+        return (viewCount * VIEW_COUNT_MULTIPLIER) + pubDateValue;
     }
 }


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 핫뉴스 조회용 조회수 저장 Redis SortedSet인 news:ranking에 들어가는 조회수 로직을 수정
단순 조회수가 아닌
조회수 + 날짜를 score형식으로 저장
들어갈수 있는 데이터는 Long 형식으로 충분한 길이
날짜는 숫자 5글자

따라서 Score는
 Score = (viewCount × 100,000) + pubDate
 
 로 계산해서 넣음
 
2025-05-28 → toEpochDay() = 20236
조회수 2회

Score = (2 × 100,000) + 20236 = 220,236
Redis Score: 220236

[포스트맨 조회수 테스트]
![image](https://github.com/user-attachments/assets/85c59906-a987-449e-a7d1-34c15a5c258e)

news:ranking에 최신뉴스만 반영
![image](https://github.com/user-attachments/assets/a5d56374-dcc7-4bcb-8caf-bc323d1d31a1)


## 🔍 리뷰어에게
- 조회수가 앞에옮으로 높은 조회수 우선 정렬 가능 (Zset 형식은 그대로)
- 같은 조회수면 최신 날짜 우선
- 카테고리별 랭킹 분리
- 3일 필터링 정상 작동 (3일 이상 오래된 데이터는 news:Ranking에 들어가지 않음)


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.