### PR TITLE
✨ Feature/#119 스트림 최대 메시지 개수 제한 설정

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/infrastructure/adapter/out/redis/RedisStreamAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/infrastructure/adapter/out/redis/RedisStreamAdapter.java
@@ -29,6 +29,7 @@ public class RedisStreamAdapter implements ChatMessageStreamPort {
 
 	private final RedisTemplate<String, String> redisTemplate;
 	private final ObjectMapper objectMapper;
+	private static final Long MAX_STREAM_SIZE = 1000L;
 	private static final String STREAM_KEY_PREFIX = "chat:stream:";
 	private static final Duration STREAM_TTL = Duration.ofDays(3);
 
@@ -38,6 +39,8 @@ public class RedisStreamAdapter implements ChatMessageStreamPort {
 	 * @param message 저장할 채팅 메시지 도메인 객체
 	 * @author 박찬병
 	 * @since 2025-05-22
+	 * @modified 2025-05-30
+	 * 2025-05-30 최대 메시지 개수 제한 설정
 	 */
 	@Override
 	public void cacheToStream(ChatMessage message) {
@@ -48,6 +51,7 @@ public class RedisStreamAdapter implements ChatMessageStreamPort {
 		MapRecord<String, String, String> record = toRecord(key, payload);
 
 		redisTemplate.opsForStream().add(record);
+		redisTemplate.opsForStream().trim(key, MAX_STREAM_SIZE);
 		redisTemplate.expire(key, STREAM_TTL);
 	}
 


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- `redisTemplate.opsForStream().trim(key, 1000L)` 코드 한 줄 추가
- Stream이 과도하게 커지는 것을 방지하여 메모리 사용을 제어합니다.


## 🔍 리뷰어에게
- 없습니다.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #119 