### PR TITLE
🐛  Fix: 뉴스 상세페이지 입장 시 채팅방 인원수 받아오는 컨트롤러 추가

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/application/service/ChatService.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/application/service/ChatService.java
@@ -99,7 +99,14 @@ public class ChatService implements ChatUseCase {
         brokerPort.deliverChatToArticle(message.getArticleId(), message);
     }
 
-
+    /**
+     * 주어진 게시글 ID에 대한 초기 채팅 세션 수를 반환한다.
+     *
+     * @param articleId 게시글 식별자
+     * @return 초기 채팅 세션 수
+     * @author 이해창
+     * @since 2025-05-24
+     */
     @Override
     public int getInitialCount(String articleId) {
         return chatSessionPort.getSessionCount(articleId);

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/infrastructure/adapter/RedisChatSessionAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/infrastructure/adapter/RedisChatSessionAdapter.java
@@ -96,11 +96,14 @@ public class RedisChatSessionAdapter implements ChatSessionPort {
      * @return 현재 채팅방에 연결된 세션 수
      * @author 이해창
      * @since 2025-05-24
+     * @modified 2025-06-01 이해창
+     * - 접속 세션 수를 즉시 발행 하여 구독자들이 세션수를 받을 수 있도록 수정
      */
     @Override
     public int getSessionCount(String articleId) {
         String roomKey = SESSION_KEY_PREFIX + articleId;
         Long count = redisTemplate.opsForSet().size(roomKey);
+        sendCountToClients(articleId, count != null ? count.intValue() : 0);
         return count != null ? count.intValue() : 0;
     }
 

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/presentation/controller/ChatController.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/presentation/controller/ChatController.java
@@ -37,7 +37,7 @@ public class ChatController {
      * @param articleId 채팅 대상 뉴스 식별자
      * @author 이해창
      * @since 2025-05-26
-     * @modified 2025-06-01
+     * @modified 2025-06-01 이해창
      * - SubscribeMapping -> MessageMapping으로 변경 및 요청 엔드포인트 변경
      */
     @MessageMapping("/chat.initCount.{articleId}")

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/presentation/controller/ChatController.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/chat/presentation/controller/ChatController.java
@@ -31,18 +31,18 @@ public class ChatController {
     /**
      * 초기 채팅방 접속 인원 수를 반환한다.
      * <p>
-     * 클라이언트가 특정 채팅방의 인원 수를 구독할 때 호출되며, 현재 접속 중인 세션 수를 응답한다.
+     * 클라이언트가 특정 채팅방의 인원 수를 구독후 호출되며, 현재 접속 중인 세션 수를 구독자에 전송한다.
      * </p>
      *
      * @param articleId 채팅 대상 뉴스 식별자
-     * @return 해당 뉴스 채팅방의 현재 세션 수 정보
      * @author 이해창
      * @since 2025-05-26
+     * @modified 2025-06-01
+     * - SubscribeMapping -> MessageMapping으로 변경 및 요청 엔드포인트 변경
      */
-    @SubscribeMapping("/topic/chat.{articleId}.count")
-    public ChatCountResponse userCount(@DestinationVariable String articleId) {
-        int count = chatUseCase.getInitialCount(articleId);
-        return new ChatCountResponse(count);
+    @MessageMapping("/chat.initCount.{articleId}")
+    public void userCount(@DestinationVariable String articleId) {
+        chatUseCase.getInitialCount(articleId);
     }
 
 }


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 이미 채팅방에 유저가 접속되어있는 상태에서, 새로운 유저가 뉴스 상세페이지에 들어오면, 
접속중인 유저 수가 제대로 표시되지 않는 문제가 있었습니다.
- 이는 잘못된 어노테이션 사용 및 실제 유저수를 웹소켓을 통해 발행하지 않아 생긴 문제로, 해당부분을 수정하였습니다.

## 🔍 리뷰어에게
- ChatController의 @SubscribeMapping을 @MessageMapping으로 교체하였습니다.
  - 프론트엔드에서 유저수 구독 후에, 현재 유저 수를 추가로 요청하도록 변경하였고, 
  해당 요청을 @MessageMapping("/chat.initCount.{articleId}") 을 통해 처리하도록 하였습니다.
- RedisChatSessionAdapter의 getSessionCount 메서드 내에서, 
현재 채팅방 유저 수를 RabbitMQ broker로 발행하도록 변경하였습니다.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #136 