### PR TITLE
♻️ Refactor: Spring Cache AOP 프록시 문제 해결을 위한 서비스 분리

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/auth/infrastructure/security/filter/JwtFilter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/auth/infrastructure/security/filter/JwtFilter.java
@@ -27,7 +27,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-    private static final String[] EXCLUDE_URLS = { "/auth", "/public" };
+    private static final String[] EXCLUDE_URLS = { "/auth", "/public", "/actuator" };
     private final JwtAuthentication jwtAuthentication;
 
     /**
@@ -72,6 +72,12 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
+        boolean shouldSkip = Arrays.stream(EXCLUDE_URLS).anyMatch(path::startsWith);
+
+        if (path.startsWith("/actuator")) {
+            System.out.println("Actuator request detected: " + path + ", shouldSkip: " + shouldSkip);
+        }
+
         return Arrays.stream(EXCLUDE_URLS).anyMatch(path::startsWith);
     }
 

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/configuration/security/SecurityConfig.java
@@ -115,7 +115,7 @@ public class SecurityConfig {
                     .requestMatchers("/ws-chat/**").permitAll() // TODO: 웹소켓 인증관련 설정 시 수정
                     .requestMatchers("/user/**").hasRole(Role.USER.getRoleName())
                     .requestMatchers("/admin/**").hasRole(Role.ADMIN.getRoleName())
-                    .requestMatchers("/actuator/prometheus", "/actuator/health", "/actuator/metrics").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .anyRequest().authenticated())
             .exceptionHandling(e -> e
                 .authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/service/PopularNewsCacheService.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/service/PopularNewsCacheService.java
@@ -1,0 +1,132 @@
+package com.likelion.backendplus4.talkpick.backend.news.info.application.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+import com.likelion.backendplus4.talkpick.backend.news.info.application.dto.PopularNewsResponse;
+import com.likelion.backendplus4.talkpick.backend.news.info.application.port.out.PopularNewsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+
+/**
+ * 인기뉴스 캐시 관리 전용 도메인 서비스입니다.
+ * <p>
+ * JVM 레벨 캐시(Spring Cache)와 Redis 캐시를 관리합니다.
+ *
+ * @since 2025-06-03
+ */
+@Service
+@RequiredArgsConstructor
+public class PopularNewsCacheService {
+
+    private final PopularNewsPort popularNewsPort;
+
+    /**
+     * Spring Cache를 통한 카테고리별 Top1 뉴스를 조회합니다.
+     * <p>
+     * 1. Spring Cache에서 먼저 조회
+     * 2. 캐시 미스 시 Redis → DB 순으로 조회
+     * 3. 조회된 결과를 Spring Cache에 저장
+     *
+     * @param category 조회할 카테고리명
+     * @return 해당 카테고리의 최고 인기뉴스, 조회 실패 시 null
+     * @author 양병학
+     * @since 2025-06-03 최초 작성
+     */
+    @Cacheable(value = "popularNews", key = "#category")
+    public PopularNewsResponse getTopNewsWithCache(String category) {
+        return fetchTopNewsFromDataSource(category);
+    }
+
+    /**
+     * 특정 카테고리의 Spring 캐시를 삭제합니다.
+     *
+     * @param category 캐시를 삭제할 카테고리명
+     * @author 양병학
+     * @since 2025-06-03 최초 작성
+     */
+    @CacheEvict(value = "popularNews", key = "#category")
+    public void evictCache(String category) {
+    }
+
+    /**
+     * 데이터 소스에서 뉴스를 조회합니다.
+     * <p>
+     * 1. Redis 캐시에서 조회 시도
+     * 2. Redis 캐시 미스 시 DB에서 조회
+     * 3. DB 조회 결과를 Redis에 저장
+     *
+     * @param category 조회할 카테고리명
+     * @return 조회된 인기뉴스, 없으면 null
+     * @author 양병학
+     * @since 2025-06-03 최초 작성
+     */
+    private PopularNewsResponse fetchTopNewsFromDataSource(String category) {
+        String topNewsId = popularNewsPort.getTop1NewsId(category);
+
+        if (null == topNewsId) {
+            return null;
+        }
+
+        PopularNewsResponse cachedNews = checkRedisCache(category, topNewsId);
+
+        if (null != cachedNews) {
+            return cachedNews;
+        }
+
+        return fetchFromDatabaseAndCache(category, topNewsId);
+    }
+
+    /**
+     * Redis 캐시에서 뉴스를 확인합니다.
+     *
+     * @param category  조회할 카테고리명
+     * @param topNewsId 확인할 뉴스 ID
+     * @return 캐시된 뉴스 데이터, 캐시 미스 시 null
+     * @author 양병학
+     * @since 2025-06-03 최초 작성
+     */
+    private PopularNewsResponse checkRedisCache(String category, String topNewsId) {
+        PopularNewsResponse cachedNews = popularNewsPort.getTopNews(category);
+
+        if (isCacheValid(cachedNews, topNewsId)) {
+            return cachedNews;
+        }
+
+        return null;
+    }
+
+    /**
+     * 캐시된 뉴스의 유효성을 검증합니다.
+     *
+     * @param cachedNews 캐시된 뉴스 데이터
+     * @param topNewsId  현재 Top1 뉴스 ID
+     * @return 유효하면 true, 그렇지 않으면 false
+     * @author 양병학
+     * @since 2025-06-03 최초 작성
+     */
+    private boolean isCacheValid(PopularNewsResponse cachedNews, String topNewsId) {
+        return null != cachedNews && Objects.equals(topNewsId, cachedNews.guid());
+    }
+
+    /**
+     * 데이터베이스에서 뉴스를 조회하고 Redis 캐시에 저장합니다.
+     *
+     * @param category  조회할 카테고리명
+     * @param topNewsId 조회할 뉴스 ID
+     * @return 조회된 뉴스 데이터
+     * @author 양병학
+     * @since 2025-06-03 최초 작성
+     */
+    private PopularNewsResponse fetchFromDatabaseAndCache(String category, String topNewsId) {
+        PopularNewsResponse freshNews = popularNewsPort.getPopularNewsResponseById(topNewsId);
+
+        if (null != freshNews) {
+            popularNewsPort.saveTopNews(category, freshNews);
+        }
+
+        return freshNews;
+    }
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/service/PopularNewsService.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/news/info/application/service/PopularNewsService.java
@@ -8,16 +8,14 @@ import com.likelion.backendplus4.talkpick.backend.news.info.exception.NewsInfoEx
 import com.likelion.backendplus4.talkpick.backend.news.info.exception.error.NewsInfoErrorCode;
 import com.likelion.backendplus4.talkpick.backend.news.info.infrastructure.redis.util.HashUtility;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
 
 /**
  * 인기뉴스 조회 서비스 구현체입니다.
- *
- * 순위 변화 감지, 캐시 관리, 뉴스 조회를 통합 관리합니다.
+ * <p>
+ * 순위 변화 감지와 캐시 전략을 관리하며, 실제 캐시 동작은 PopularNewsCacheService에 위임합니다.
  *
  * @since 2025-05-27
  */
@@ -25,11 +23,12 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PopularNewsService implements PopularNewsUseCase {
 
+    private final PopularNewsCacheService cacheService;
     private final PopularNewsPort popularNewsPort;
 
     /**
      * 특정 카테고리의 Top1 인기뉴스를 조회합니다.
-     *
+     * <p>
      * 1. 해당 카테고리의 순위 변화 감지 (해시 비교)
      * 2. 변화가 감지되면 캐시 무효화 처리
      * 3. Spring Cache를 통해 인기뉴스 조회
@@ -38,108 +37,35 @@ public class PopularNewsService implements PopularNewsUseCase {
      * @param categoryName 조회할 카테고리 한글명
      * @return 해당 카테고리의 Top1 인기뉴스
      * @throws NewsInfoException 뉴스 정보 조회 중 오류가 발생한 경우
+     * @author 양병학
+     * @since 2025-05-27 최초 작성
      */
     @Override
     @CachePerformanceTracker
     public PopularNewsResponse getTopNewsByCategory(String categoryName) {
-        if (hasRankingChanged(categoryName)) {
-            evictCache(categoryName);
-        }
-        return getTopNewsWithCache(categoryName);
-    }
 
-    /**
-     * Spring Cache를 통한 카테고리별 Top1 뉴스를 조회합니다.
-     *
-     * @param category 조회할 카테고리명
-     * @return 해당 카테고리의 최고 인기뉴스, 조회 실패 시 null
-     */
-    @Cacheable(value = "popularNews", key = "#category")
-    public PopularNewsResponse getTopNewsWithCache(String category) {
-        return fetchTopNewsFromDataSource(category);
-    }
+        boolean rankingChanged = hasRankingChanged(categoryName);
 
-    /**
-     * 특정 카테고리의 Spring 캐시를 삭제합니다.
-     *
-     * @param category 캐시를 삭제할 카테고리명
-     */
-    @CacheEvict(value = "popularNews", key = "#category")
-    public void evictCache(String category) {
-    }
-
-    /**
-     * 데이터 소스에서 뉴스를 조회합니다.
-     *
-     * @param category 조회할 카테고리명
-     * @return 조회된 인기뉴스, 없으면 null
-     */
-    private PopularNewsResponse fetchTopNewsFromDataSource(String category) {
-        String topNewsId = popularNewsPort.getTop1NewsId(category);
-
-        if (null == topNewsId) {
-            return null;
+        if (rankingChanged) {
+            cacheService.evictCache(categoryName);
         }
 
-        PopularNewsResponse cachedNews = checkRedisCache(category, topNewsId);
+        PopularNewsResponse result = cacheService.getTopNewsWithCache(categoryName);
 
-        if (null != cachedNews) {
-            return cachedNews;
-        }
-
-        return fetchFromDatabaseAndCache(category, topNewsId);
-    }
-
-    /**
-     * Redis 캐시에서 뉴스를 확인합니다.
-     *
-     * @param category  조회할 카테고리명
-     * @param topNewsId 확인할 뉴스 ID
-     * @return 캐시된 뉴스 데이터, 캐시 미스 시 null
-     */
-    private PopularNewsResponse checkRedisCache(String category, String topNewsId) {
-        PopularNewsResponse cachedNews = popularNewsPort.getTopNews(category);
-
-        if (isCacheValid(cachedNews, topNewsId)) {
-            return cachedNews;
-        }
-
-        return null;
-    }
-
-    /**
-     * 캐시된 뉴스의 유효성을 검증합니다.
-     *
-     * @param cachedNews 캐시된 뉴스 데이터
-     * @param topNewsId  현재 Top1 뉴스 ID
-     * @return 유효하면 true, 그렇지 않으면 false
-     */
-    private boolean isCacheValid(PopularNewsResponse cachedNews, String topNewsId) {
-        return null != cachedNews && Objects.equals(topNewsId, cachedNews.guid());
-    }
-
-    /**
-     * 데이터베이스에서 뉴스를 조회하고 Redis 캐시에 저장합니다.
-     *
-     * @param category  조회할 카테고리명
-     * @param topNewsId 조회할 뉴스 ID
-     * @return 조회된 뉴스 데이터
-     */
-    private PopularNewsResponse fetchFromDatabaseAndCache(String category, String topNewsId) {
-        PopularNewsResponse freshNews = popularNewsPort.getPopularNewsResponseById(topNewsId);
-
-        if (null != freshNews) {
-            popularNewsPort.saveTopNews(category, freshNews);
-        }
-
-        return freshNews;
+        return result;
     }
 
     /**
      * 순위 변화를 감지합니다.
+     * <p>
+     * 1. 현재 순위의 해시값 계산
+     * 2. 저장된 해시값과 비교
+     * 3. 변화가 있으면 새 해시값 저장 후 true 반환
      *
      * @param category 확인할 카테고리명 (한글)
      * @return 순위가 변화했으면 true, 그렇지 않으면 false
+     * @author 양병학
+     * @since 2025-05-27 최초 작성
      */
     private boolean hasRankingChanged(String category) {
         String currentHash = calculateCurrentRankingHash(category);
@@ -158,6 +84,8 @@ public class PopularNewsService implements PopularNewsUseCase {
      *
      * @param category 해시를 계산할 카테고리명 (한글)
      * @return 계산된 해시값
+     * @author 양병학
+     * @since 2025-05-27 최초 작성
      */
     private String calculateCurrentRankingHash(String category) {
         String top1Data = popularNewsPort.getTop1NewsWithScore(category);
@@ -177,6 +105,8 @@ public class PopularNewsService implements PopularNewsUseCase {
      * @param currentHash 현재 해시값
      * @param savedHash   저장된 해시값
      * @return 변화했으면 true, 그렇지 않으면 false
+     * @author 양병학
+     * @since 2025-05-27 최초 작성
      */
     private boolean isHashChanged(String currentHash, String savedHash) {
         return !Objects.equals(currentHash, savedHash);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,8 +101,6 @@ cache:
   expire-after-write: 6h
 
 management:
-  server:
-    port: ${BACKEND_ACTUATOR_PORT:8078}
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
-  SecurityConfig → 모든 Actuator 경로 허용
- Spring Cache AOP 내부 호출 문제 해결을 위해 캐시 관리 로직을 별도 서비스로 분리
PopularNewsCacheService 신규 생성: 캐시 관리 전용 서비스
PopularNewsService: 비즈니스 로직 조합에 집중


## 🔍 리뷰어에게
- 저번에 수정했던 트러블인데 [트러블노트](https://www.notion.so/Cacheable-AOP-2001f5b7c2a2801490b4d5cbc6b25233?source=copy_link)
작업하면서 리팩토링하는과정에서 다시 하나로 합쳐졌나봅니다.
캐시작동을 위해서 분리했습니다. 분리후 작동 후 잘되는거 확인했습니다

- 인가부분인 securityConfig에서 처리중인데
사실 actuator는 항상열어둬도 되서 인증부분은 JWTFilter에서 수정해도 되겠다 했는데
작업후에 401(인증에러)가 뜨길래 일단 config 수정으로 남겨놓고 올려습니다.

## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


##🔗 관련 이슈
Closes #145