### PR TITLE
Feature/#157 채팅인기뉴스 실시간업데이트 문제수정

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/backend/common/config/CacheConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/backend/common/config/CacheConfig.java
@@ -36,15 +36,23 @@ public class CacheConfig {
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+
         cacheManager.setCaffeine(Caffeine.newBuilder()
                 .maximumSize(maximumSize)
                 .expireAfterWrite(expireAfterWrite)
                 .recordStats());
 
         cacheManager.setCacheNames(List.of(
-                "popularNews",
-                "chatTopNews"
+                "popularNews"
         ));
+
+        cacheManager.registerCustomCache("chatTopNews",
+                Caffeine.newBuilder()
+                        .maximumSize(maximumSize)
+                        .expireAfterWrite(Duration.ofSeconds(30))
+                        .recordStats()
+                        .build());
+
 
         return cacheManager;
     }


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
🐛 문제점

채팅 기반 인기 뉴스가 실시간으로 업데이트되지 않는 문제 해결
기존 JVM 캐시(Caffeine)에 TTL이 없어서 초기 로딩 후 데이터가 무한정 고정됨
사용자가 더 인기있는 채팅방으로 이동해도 랭킹이 반영되지 않았음

🔧 해결방법
CacheConfig.java 수정:

chatTopNews 캐시에 30초 TTL 설정
registerCustomCache를 통해 별도 캐시 설정 적용
기존 popularNews 캐시는 6시간 TTL 유지 (해시기반 변경감지로직이 있음)

📈 성능 개선 효과

Redis 조회 빈도 대폭 감소: 요청 수만큼 → 30초마다 1회
사용자 응답시간 개선: Lua기반 무거운 Redis 조회(KEYS + 전체 순회) 부하 감소 (for문 O(n))
실시간성 확보: 30초마다 최신 인기 채팅방 데이터 반영

![image](https://github.com/user-attachments/assets/f2ce8d72-7b24-4c11-8e78-6e9de10d0633)
![image](https://github.com/user-attachments/assets/8bc8be2a-d89e-44b3-a042-62b6573943c9)
테스트 시나리오:

초기 상태에서 인기 채팅방 A 표시
30초 후 더 많은 참여자를 가진 채팅방 B로 자동 업데이트
모든 채팅방 참여자가 0명이 되면 인기 채팅방 메뉴 자동 숨김 (기존 프론트 로직)

![image](https://github.com/user-attachments/assets/5e14b097-7e5c-4633-bce7-c762ac5b6d89)
![image](https://github.com/user-attachments/assets/628face4-6264-4973-bfd5-e1af09adffe0)
이후 더 많은 인원수가 나오면 30초단위로 더 많은쪽으로 업데이트

## 🔍 리뷰어에게
- TTL 시간: 30초가 적절한지 (실시간성 vs 성능)


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- `closed #157`